### PR TITLE
adding a catch for no files found on ftp request

### DIFF
--- a/lib/sec_query/filing.rb
+++ b/lib/sec_query/filing.rb
@@ -59,6 +59,7 @@ module SecQuery
           filings_for_index(file).each(&blk)
         end
       end
+    rescue Net::FTPTempError
     end
 
     def self.filings_for_index(index)

--- a/spec/sec_query/filing_spec.rb
+++ b/spec/sec_query/filing_spec.rb
@@ -53,6 +53,10 @@ describe SecQuery::Filing do
       expect(filing1.link)
         .to eq('http://www.sec.gov/Archives/edgar/data/1551138/0001144204-12-064668.txt')
     end
+
+    it 'returns nil if for_date is run on a market close day' do
+      expect(SecQuery::Filing.for_date(Date.parse('20120101'))).to eq(nil)
+    end
   end
 
   describe '::recent', vcr: { cassette_name: 'recent' } do


### PR DESCRIPTION
If a `for_date` request is made on a market close day it raises 
