### PR TITLE
Generically scope filing queries by search params

### DIFF
--- a/lib/sec_query/entity.rb
+++ b/lib/sec_query/entity.rb
@@ -15,8 +15,8 @@ module SecQuery
       end
     end
 
-    def filings
-      Filing.find(@cik)
+    def filings(args={})
+      Filing.find(@cik, 0, 80, args)
     end
 
     def self.query(url)

--- a/lib/sec_query/filing.rb
+++ b/lib/sec_query/filing.rb
@@ -134,12 +134,14 @@ module SecQuery
       end
     end
 
-    def self.find(cik, start = 0, count = 80)
+    def self.find(cik, start = 0, count = 80, args={})
       temp = {}
       temp[:url] = SecURI.browse_edgar_uri({cik: cik})
       temp[:url][:action] = :getcompany
       temp[:url][:start] = start
       temp[:url][:count] = count
+      args.each {|k,v| temp[:url][k]=v }
+      
       response = Entity.query(temp[:url].output_atom.to_s)
       document = Nokogiri::HTML(response)
       parse(cik, document)


### PR DESCRIPTION
This change enables filing queries to be scoped by any query parameter that SEC supports. For example, by passing args={type: "10-K"}, only 10-K filings will get queried. This is helpful for larger companies that have many filings (> 80), before you get to the desired type of filing.

Prior arguments (start and count) are left intact for backward compatibility.