### PR TITLE
Remove support for FTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,6 @@ SecQuery::Filing instance may contains the following attributes:
 
 #### Class Methods
 
-##### .for_date
-
-Find filings by a specific Date:
-
-`SecQuery::Filing.for_date(Date.parse('20121123'))`
-
-Returns a list of SecQuery::Filing instances.
-
 ##### .recent
 
 Find filings by a specific Date:

--- a/lib/sec_query/filing.rb
+++ b/lib/sec_query/filing.rb
@@ -45,23 +45,6 @@ module SecQuery
       return
     end
 
-    def self.for_date(date, &blk)
-      ftp = Net::FTP.new('ftp.sec.gov')
-      ftp.login
-      file_name = ftp.nlst("edgar/daily-index/#{ date.to_sec_uri_format }*")[0]
-      ftp.close
-      open("ftp://ftp.sec.gov/#{ file_name }") do |file|
-        if file_name[-2..-1] == 'gz'
-          gz_reader = Zlib::GzipReader.new(file)
-          gz_reader.rewind
-          filings_for_index(gz_reader).each(&blk)
-        else
-          filings_for_index(file).each(&blk)
-        end
-      end
-    rescue Net::FTPTempError
-    end
-
     def self.filings_for_index(index)
       [].tap do |filings|
         content_section = false

--- a/spec/sec_query/filing_spec.rb
+++ b/spec/sec_query/filing_spec.rb
@@ -35,30 +35,6 @@ describe SecQuery::Filing do
     end
   end
 
-  describe '::for_date' do
-    let(:filings) do
-      [].tap do |filings|
-        SecQuery::Filing.for_date(Date.parse('20121123')) do |f|
-          filings << f
-        end
-      end
-    end
-
-    let(:filing1) { filings.first }
-
-    it 'correctly parses a filing from a zipped company index' do
-      expect(filing1.term).to eq('4')
-      expect(filing1.cik).to eq('1551138')
-      expect(filing1.date).to eq(Date.parse('20121123'))
-      expect(filing1.link)
-        .to eq('https://www.sec.gov/Archives/edgar/data/1551138/0001144204-12-064668.txt')
-    end
-
-    it 'returns nil if for_date is run on a market close day' do
-      expect(SecQuery::Filing.for_date(Date.parse('20120101'))).to eq(nil)
-    end
-  end
-
   describe '::recent', vcr: { cassette_name: 'recent' } do
     let(:filings) { [] }
 


### PR DESCRIPTION
  * SEC stopped supporting FTP in Dec 2016
    * https://www.sec.gov/edgar/searchedgar/accessing-edgar-data.htm