### PR TITLE
Addressing bundler-audit found vulnerabilities; Updating rspec syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in sec_query.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,22 @@
 PATH
   remote: .
   specs:
-    sec_query (1.2.0)
+    sec_query (1.3.0)
       addressable (~> 2.5)
       nokogiri (~> 1.7)
       rest-client (~> 2.0)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     addressable (2.5.0)
       public_suffix (~> 2.0, >= 2.0.2)
-    ast (2.3.0)
+    ast (2.4.0)
     byebug (9.0.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
-    domain_name (0.5.20161129)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     hashdiff (0.3.2)
     http-cookie (1.0.3)
@@ -24,16 +24,17 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.3.0)
     netrc (0.11.0)
-    nokogiri (1.7.0.1)
-      mini_portile2 (~> 2.1.0)
-    parser (2.3.3.1)
-      ast (~> 2.2)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    parallel (1.12.1)
+    parser (2.4.0.2)
+      ast (~> 2.3)
     powerpack (0.1.1)
     public_suffix (2.0.5)
-    rainbow (2.2.1)
-    rest-client (2.0.0)
+    rainbow (3.0.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -50,18 +51,19 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
-    rubocop (0.47.1)
-      parser (>= 2.3.3.1, < 3.0)
+    rubocop (0.52.1)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.8.1)
+    ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
-    unicode-display_width (1.1.3)
+    unf_ext (0.0.7.5)
+    unicode-display_width (1.3.0)
     vcr (3.0.3)
     webmock (2.3.2)
       addressable (>= 2.3.6)
@@ -80,4 +82,4 @@ DEPENDENCIES
   webmock (~> 2.3)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/spec/sec_query/filing_spec.rb
+++ b/spec/sec_query/filing_spec.rb
@@ -63,7 +63,7 @@ describe SecQuery::Filing do
   describe "::find" do
     shared_examples_for "it found filings" do
       it "should return an array of filings" do
-        filings.should be_kind_of(Array)
+        expect(filings).to be_kind_of(Array)
       end
 
       it "the filings should be valid" do
@@ -88,7 +88,7 @@ describe SecQuery::Filing do
         it_behaves_like "it found filings"
 
         it "should only return filings of type" do
-          filings.first.term.should == "10-K"
+          expect(filings.first.term).to eq "10-K"
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,23 +7,23 @@ require 'support/vcr'
 
 def is_valid?(entity)
   expect(entity).to_not be_nil
-  entity.name.should  == query[:name]
-  entity.cik.should == query[:cik]
+  expect(entity.name).to eq query[:name]
+  expect(entity.cik).to eq query[:cik]
   entity.instance_variables.each do |key|
-    SecQuery::Entity::COLUMNS.should include(key[1..-1].to_sym)
+    expect(SecQuery::Entity::COLUMNS).to include(key[1..-1].to_sym)
   end
 end
 
 def is_valid_address?(address)
   expect(address).to_not be_nil
   address.keys.each do |key|
-    ['city', 'state', 'street1', 'street2', 'type', 'zip', 'phone'].should include(key)
+    expect(['city', 'state', 'street1', 'street2', 'type', 'zip', 'phone']).to include(key)
   end
 end
 
 def is_valid_filing?(filing)
   expect(filing).to_not be_nil
   filing.instance_variables.each do |key|
-    SecQuery::Filing::COLUMNS.should include(key[1..-1].to_sym)
+    expect(SecQuery::Filing::COLUMNS).to include(key[1..-1].to_sym)
   end
 end


### PR DESCRIPTION
1. [Bundler-Audit](https://github.com/rubysec/bundler-audit) finds a vulnerability with the `rubocop -v 0.47.1` and also `http://rubygems.org` as a gem source instead of `https://rubygems.org` - Updating Gemfiles.
2. Updating rspec `should` to use `expect` syntax, to fix rspec deprecation warnings.