### PR TITLE
Add missing activesupport dependency to gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     sec_query (1.3.0)
+      activesupport
       addressable (~> 2.5)
       nokogiri (~> 1.7)
       rest-client (~> 2.0)
@@ -9,10 +10,16 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     byebug (9.1.0)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
@@ -21,10 +28,13 @@ GEM
     hashdiff (0.3.7)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
+    minitest (5.11.3)
     netrc (0.11.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -60,6 +70,9 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)

--- a/sec_query.gemspec
+++ b/sec_query.gemspec
@@ -2,7 +2,6 @@
 $:.push File.expand_path('../lib', __FILE__)
 
 require 'sec_query/version'
-require 'sec_query'
 
 Gem::Specification.new do |s|
   s.name        = 'sec_query'
@@ -28,4 +27,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rest-client', '~> 2.0'
   s.add_runtime_dependency 'addressable', '~> 2.5'
   s.add_runtime_dependency 'nokogiri', '~> 1.7'
+  s.add_runtime_dependency 'activesupport', '>= 0'
 end


### PR DESCRIPTION
I ran into this when requiring `sec_query` after a fresh install.

```rb
irb(main):001:0> require 'sec_query'
...
LoadError (cannot load such file -- active_support/all)
```

So I added an open-ended `activesupport` dependency.


Additionally, when bundling within the `sec_query` directory I ran into:

```sh
$ bundle                                                                                                                                                                                           

[!] There was an error parsing `Gemfile`: 
[!] There was an error while loading `sec_query.gemspec`: cannot load such file -- active_support/all
Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue.

 #  from .../sec_query/sec_query.gemspec:5
 #  -------------------------------------------
 #  require 'sec_query/version'
 >  require 'sec_query'
 #  
 #  -------------------------------------------
. Bundler cannot continue.

 #  from .../sec_query/Gemfile:4
 #  -------------------------------------------
 #  # Specify your gem's dependencies in sec_query.gemspec
 >  gemspec
 #  -------------------------------------------
```

So I removed the `require 'sec_query'` from the gemspec - I don't think it's needed.