### PR TITLE
SecQuery::FilingDetail

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,27 @@ end
 
 Requires a block. Returns the most recent filings. Use start, count and limit to iterate through recent filings.
 
+### Sec::FilingDetail
+Represents the deail page for a given filing. 
+Ex: [Filing Detail page](https://www.sec.gov/Archives/edgar/data/320193/000032019317000070/0000320193-17-000070-index.htm) of Apple's Annual Report from 2017
+
+#### Instance Methods
+* link
+* filing_date
+* accepted_date
+* period_of_report
+* sec_access_number
+* document_count
+* format_files
+* data_files
+
+#### Class Methods
+##### .fetch
+```
+appl_10k_details_url = 'https://www.sec.gov/Archives/edgar/data/320193/000032019317000070/0000320193-17-000070-index.htm'
+filing_detail = SecQuery::FilingDetail.fetch(appl_10k_details_url)
+```
+
 ## To Whom It May Concern at the SEC
 
 Over the last decade, I have gotten to know Edgar quite extensively and I have grown quite fond of it and the information it contains. So it is with my upmost respect that I make the following suggestions:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Middle initial or name is optional, but helps when there are multiple results fo
 
 Returns a list of Sec::Filing instances for an Sec::Entity
 
-### Sec::Filing
+### SecQuery::Filing
 
 SecQuery::Filing instance may contains the following attributes:
 
@@ -115,7 +115,7 @@ end
 
 Requires a block. Returns the most recent filings. Use start, count and limit to iterate through recent filings.
 
-### Sec::FilingDetail
+### SecQuery::FilingDetail
 Represents the deail page for a given filing. 
 Ex: [Filing Detail page](https://www.sec.gov/Archives/edgar/data/320193/000032019317000070/0000320193-17-000070-index.htm) of Apple's Annual Report from 2017
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ SecQuery::Filing instance may contains the following attributes:
 * term
 * date
 * file_id
+* detail
 
 #### Class Methods
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ end
 Requires a block. Returns the most recent filings. Use start, count and limit to iterate through recent filings.
 
 ### SecQuery::FilingDetail
-Represents the deail page for a given filing. 
+Represents the detail page for a given filing. 
 Ex: [Filing Detail page](https://www.sec.gov/Archives/edgar/data/320193/000032019317000070/0000320193-17-000070-index.htm) of Apple's Annual Report from 2017
 
 #### Instance Methods

--- a/lib/sec_query.rb
+++ b/lib/sec_query.rb
@@ -12,5 +12,6 @@ require 'rubygems'
 # internal
 require 'sec_query/entity'
 require 'sec_query/filing'
+require 'sec_query/filing_detail'
 require 'sec_query/sec_uri'
 require 'sec_query/version'

--- a/lib/sec_query/filing.rb
+++ b/lib/sec_query/filing.rb
@@ -14,6 +14,10 @@ module SecQuery
       end
     end
 
+    def detail
+      @detail ||= FilingDetail.fetch(@link)
+    end
+
     def self.fetch(uri, &blk)
       open(uri) do |rss|
         parse_rss(rss, &blk)

--- a/lib/sec_query/filing_detail.rb
+++ b/lib/sec_query/filing_detail.rb
@@ -15,7 +15,7 @@ module SecQuery
     end
 
     def self.fetch(uri)
-      document = Nokogiri::HTML(open(uri))
+      document = Nokogiri::HTML(open(uri.gsub('http:', 'https:')))
       filing_date = document.xpath('//*[@id="formDiv"]/div[2]/div[1]/div[2]').text
       accepted_date = document.xpath('//*[@id="formDiv"]/div[2]/div[1]/div[4]').text
       period_of_report = document.xpath('//*[@id="formDiv"]/div[2]/div[2]/div[2]').text
@@ -49,7 +49,7 @@ module SecQuery
       format_files_table.xpath('//tr').each_with_index do |row, i|
         rows[i] = {}
         row.xpath('td').each_with_index do |td, j|
-          if td.children.first&.name == 'a'
+          if td.children.first && td.children.first.name == 'a'
             relative_url = td.children.first.attributes.first[1].value
             rows[i][headers[j]] = {
                 'link' => "https://www.sec.gov#{relative_url}",

--- a/lib/sec_query/filing_detail.rb
+++ b/lib/sec_query/filing_detail.rb
@@ -1,0 +1,67 @@
+# encoding: UTF-8
+
+module SecQuery
+  # => SecQuery::FilingDetail
+  # SecQuery::FilingDetail requests and parses Filing Detail for any given SecQuery::Filing
+  class FilingDetail
+    COLUMNS = [:link, :filing_date, :accepted_date, :period_of_report, :sec_access_number, :document_count, :format_files, :data_files]
+
+    attr_accessor(*COLUMNS)
+
+    def initialize(filing_detail)
+      COLUMNS.each do |column|
+        instance_variable_set("@#{ column }", filing_detail[column])
+      end
+    end
+
+    def self.fetch(uri)
+      document = Nokogiri::HTML(open(uri))
+      filing_date = document.xpath('//*[@id="formDiv"]/div[2]/div[1]/div[2]').text
+      accepted_date = document.xpath('//*[@id="formDiv"]/div[2]/div[1]/div[4]').text
+      period_of_report = document.xpath('//*[@id="formDiv"]/div[2]/div[2]/div[2]').text
+      sec_access_number = document.xpath('//*[@id="secNum"]/text()').text.strip
+      document_count = document.xpath('//*[@id="formDiv"]/div[2]/div[1]/div[6]').text.to_i
+      format_files_table = document.xpath("//table[@summary='Document Format Files']")
+      data_files_table = document.xpath("//table[@summary='Data Files']")
+
+      format_files = (parsed = parse_files(format_files_table)) && (parsed || [])
+      data_files = (parsed = parse_files(data_files_table)) && (parsed || [])
+
+      new({uri: uri,
+           filing_date: filing_date,
+           accepted_date: accepted_date,
+           period_of_report: period_of_report,
+           sec_access_number: sec_access_number,
+           document_count: document_count,
+           format_files: format_files,
+           data_files: data_files})
+    end
+
+    def self.parse_files(format_files_table)
+      # get table headers
+      headers = []
+      format_files_table.xpath('//th').each do |th|
+        headers << th.text
+      end
+
+      # get table rows
+      rows = []
+      format_files_table.xpath('//tr').each_with_index do |row, i|
+        rows[i] = {}
+        row.xpath('td').each_with_index do |td, j|
+          if td.children.first&.name == 'a'
+            relative_url = td.children.first.attributes.first[1].value
+            rows[i][headers[j]] = {
+                'link' => "https://www.sec.gov#{relative_url}",
+                'text' => td.text.gsub(/\A\p{Space}*/, '')
+            }
+          else
+            rows[i][headers[j]] = td.text.gsub(/\A\p{Space}*/, '')
+          end
+        end
+      end
+
+      rows.reject(&:empty?)
+    end
+  end
+end


### PR DESCRIPTION
- Adding `SecQuery::FilingDetail` for parsing the "Filing Detail" EDGAR page of a filing.
- Adding the `.detail` method to `SecQuery::Filing` instances.