### PR TITLE
Revert "Adding helper method .last to SecQuery::Filing instances"

### DIFF
--- a/lib/sec_query/filing.rb
+++ b/lib/sec_query/filing.rb
@@ -142,10 +142,6 @@ module SecQuery
       parse(cik, document)
     end
 
-    def self.last(cik, args = {})
-      find(cik, 0, 1, args)&.first
-    end
-
     def self.parse(cik, document)
       filings = []
       if document.xpath('//content').to_s.length > 0

--- a/spec/sec_query/filing_spec.rb
+++ b/spec/sec_query/filing_spec.rb
@@ -101,30 +101,6 @@ describe SecQuery::Filing do
         expect(f.content).to match(/^(<SEC-DOCUMENT>)/)
       end
     end
-
-    describe "::last", vcr: { cassette_name: "Steve Jobs"} do
-      let(:cik) { "0000320193" }
-
-      context 'when querying by cik' do
-        let(:filing) { SecQuery::Filing.last(cik) }
-
-        it 'returns the first filing' do
-          expect(filing).to be_kind_of(SecQuery::Filing)
-          is_valid_filing?(filing)
-        end
-      end
-
-      context 'when querying cik and by type param' do
-        let(:filing) { SecQuery::Filing.last(cik,{ type: "10-K" }) }
-
-        describe "Filings", vcr: { cassette_name: "Steve Jobs"} do
-          it "should return filing of type 10-K" do
-            expect(filing).to be_kind_of(SecQuery::Filing)
-            expect(filing.term).to eq "10-K"
-          end
-        end
-      end
-    end
   end
 
   describe '#detail', vcr: { cassette_name: 'Steve Jobs'} do


### PR DESCRIPTION
@david-christensen Reverting tyrauber/sec_query#47. This branch fails in [Ruby 2.2.10](https://travis-ci.com/tyrauber/sec_query/builds/87992392).

