### PR TITLE
Fixing aapl test

### DIFF
--- a/spec/sec_query/entity_spec.rb
+++ b/spec/sec_query/entity_spec.rb
@@ -7,7 +7,7 @@ describe SecQuery::Entity do
 
   describe "Company Queries", vcr: { cassette_name: "aapl"} do
 
-    let(:query){{name: "APPLE INC", sic: "3571", symbol: "aapl", cik:"0000320193"}}
+    let(:query){{name: "Apple Inc.", sic: "3571", symbol: "aapl", cik:"0000320193"}}
     
     [:symbol, :cik, :name].each do |key|
       context "when quering by #{key}" do


### PR DESCRIPTION
Fixing these failures.

```
F..FF..FF..F.................................

Failures:

  1) SecQuery::Entity Company Queries when quering by symbol as hash should be valid
     Failure/Error: expect(entity.name).to eq query[:name]
     
       expected: "APPLE INC"
            got: "Apple Inc."
     
       (compared using ==)
     # ./spec/spec_helper.rb:10:in `is_valid?'
     # ./spec/sec_query/entity_spec.rb:19:in `block (6 levels) in <top (required)>'

  2) SecQuery::Entity Company Queries when quering by symbol as string should be valid
     Failure/Error: expect(entity.name).to eq query[:name]
     
       expected: "APPLE INC"
            got: "Apple Inc."
     
       (compared using ==)
     # ./spec/spec_helper.rb:10:in `is_valid?'
     # ./spec/sec_query/entity_spec.rb:34:in `block (6 levels) in <top (required)>'

  3) SecQuery::Entity Company Queries when quering by cik as hash should be valid
     Failure/Error: expect(entity.name).to eq query[:name]
     
       expected: "APPLE INC"
            got: "Apple Inc."
     
       (compared using ==)
     # ./spec/spec_helper.rb:10:in `is_valid?'
     # ./spec/sec_query/entity_spec.rb:19:in `block (6 levels) in <top (required)>'

  4) SecQuery::Entity Company Queries when quering by cik as string should be valid
     Failure/Error: expect(entity.name).to eq query[:name]
     
       expected: "APPLE INC"
            got: "Apple Inc."
     
       (compared using ==)
     # ./spec/spec_helper.rb:10:in `is_valid?'
     # ./spec/sec_query/entity_spec.rb:34:in `block (6 levels) in <top (required)>'

  5) SecQuery::Entity Company Queries when quering by name as hash should be valid
     Failure/Error: expect(entity.name).to eq query[:name]
     
       expected: "APPLE INC"
            got: "Apple Inc."
     
       (compared using ==)
     # ./spec/spec_helper.rb:10:in `is_valid?'
     # ./spec/sec_query/entity_spec.rb:19:in `block (6 levels) in <top (required)>'

  6) SecQuery::Entity Company Queries when quering by name as string should be valid
     Failure/Error: expect(entity.name).to eq query[:name]
     
       expected: "APPLE INC"
            got: "Apple Inc."
     
       (compared using ==)
     # ./spec/spec_helper.rb:10:in `is_valid?'
     # ./spec/sec_query/entity_spec.rb:34:in `block (6 levels) in <top (required)>'

Finished in 2.46 seconds (files took 1.42 seconds to load)
45 examples, 6 failures

Failed examples:

rspec ./spec/sec_query/entity_spec.rb[1:1:1:1:1] # SecQuery::Entity Company Queries when quering by symbol as hash should be valid
rspec ./spec/sec_query/entity_spec.rb[1:1:1:2:1] # SecQuery::Entity Company Queries when quering by symbol as string should be valid
rspec ./spec/sec_query/entity_spec.rb[1:1:2:1:1] # SecQuery::Entity Company Queries when quering by cik as hash should be valid
rspec ./spec/sec_query/entity_spec.rb[1:1:2:2:1] # SecQuery::Entity Company Queries when quering by cik as string should be valid
rspec ./spec/sec_query/entity_spec.rb[1:1:3:1:1] # SecQuery::Entity Company Queries when quering by name as hash should be valid
rspec ./spec/sec_query/entity_spec.rb[1:1:3:2:1] # SecQuery::Entity Company Queries when quering by name as string should be valid
```