### PR TITLE
Support SecQuery::Entity.find('googl')

### DIFF
--- a/lib/sec_query/sec_uri.rb
+++ b/lib/sec_query/sec_uri.rb
@@ -49,7 +49,7 @@ module SecQuery
       begin Float(string_arg)
         options[:CIK] = string_arg
       rescue
-        if string_arg.length <= 4
+        if string_arg.length <= 5
           options[:CIK] = string_arg
         else
           options[:company] = string_arg.gsub(/[(,?!\''"":.)]/, '')

--- a/spec/sec_query/entity_spec.rb
+++ b/spec/sec_query/entity_spec.rb
@@ -7,7 +7,7 @@ describe SecQuery::Entity do
 
   describe "Company Queries", vcr: { cassette_name: "aapl"} do
 
-    let(:query){{name: "APPLE INC", sic: "3571", symbol: "aapl", cik:"0000320193"}}
+    let(:query){{name: "Apple Inc.", sic: "3571", symbol: "aapl", cik:"0000320193"}}
     
     [:symbol, :cik, :name].each do |key|
       context "when quering by #{key}" do

--- a/spec/sec_query/entity_spec.rb
+++ b/spec/sec_query/entity_spec.rb
@@ -37,7 +37,40 @@ describe SecQuery::Entity do
       end
     end
   end
-  
+
+  describe "Company Queries - Alphabet Inc.", vcr: { cassette_name: "googl"} do
+
+    let(:query){{name: "Alphabet Inc.", sic: "7370", symbol: "googl", cik:"0001652044"}}
+
+    [:symbol, :cik, :name].each do |key|
+      context "when quering by #{key}" do
+        describe "as hash" do
+
+          let(:entity){ SecQuery::Entity.find({ key => query[key] }) }
+
+          it "should be valid" do
+            is_valid?(entity)
+          end
+
+          it "should have a valid mailing address" do
+            is_valid_address?(entity.mailing_address)
+          end
+
+          it "should have a valid business address" do
+            is_valid_address?(entity.business_address)
+          end
+        end
+
+        describe "as string" do
+          it "should be valid" do
+            entity = SecQuery::Entity.find(query[key])
+            is_valid?(entity)
+          end
+        end
+      end
+    end
+  end
+
   describe "People Queries", vcr: { cassette_name: "Steve Jobs"} do
   
     let(:query){ { name: "JOBS STEVEN P", :cik => "0001007844" } }

--- a/spec/sec_query/sec_uri_spec.rb
+++ b/spec/sec_query/sec_uri_spec.rb
@@ -28,10 +28,10 @@ describe SecQuery::SecURI do
         .to eq('https://www.sec.gov/cgi-bin/browse-edgar?CIK=AAPL')
     end
 
-    it 'builds a default /browse-edgar/ url with options: "Apple"' do
-      uri = SecQuery::SecURI.browse_edgar_uri('Apple')
+    it 'builds a default /browse-edgar/ url with options: "Apple Inc"' do
+      uri = SecQuery::SecURI.browse_edgar_uri('Apple Inc')
       expect(uri.to_s)
-        .to eq('https://www.sec.gov/cgi-bin/browse-edgar?company=Apple')
+        .to eq('https://www.sec.gov/cgi-bin/browse-edgar?company=Apple%20Inc')
     end
   end
 


### PR DESCRIPTION
This PR is based off of the branch of: [Fixing aapl test - PR #55](https://github.com/tyrauber/sec_query/pull/55) 

The change to `lib/sec_query/sec_uri.rb` allows the new test to pass.
Without the change the test output looks like:
```
Failures:

  1) SecQuery::Entity Company Queries - Alphabet Inc. when quering by symbol as string should be valid
     Failure/Error: if content['company_info'].present?
     
     NoMethodError:
       undefined method `[]' for nil:NilClass
     # ./lib/sec_query/entity.rb:45:in `parse'
     # ./lib/sec_query/entity.rb:40:in `find'
     # ./spec/sec_query/entity_spec.rb:66:in `block (6 levels) in <top (required)>'

Finished in 1.46 seconds (files took 1.52 seconds to load)
32 examples, 1 failure

Failed examples:

rspec ./spec/sec_query/entity_spec.rb[1:2:1:2:1] # SecQuery::Entity Company Queries - Alphabet Inc. when quering by symbol as string should be valid
```