### PR TITLE
Return nil when Entity not found.

### DIFF
--- a/lib/sec_query/entity.rb
+++ b/lib/sec_query/entity.rb
@@ -37,12 +37,14 @@ module SecQuery
       response = query(temp[:url].output_atom.to_s)
       document = Nokogiri::HTML(response)
       xml = document.xpath("//feed/company-info")
-      Entity.new(parse(xml))
+      parsed_xml =  parse(xml)
+      return if parsed_xml.empty?
+      Entity.new(parsed_xml)
     end
 
     def self.parse(xml)
       content = Hash.from_xml(xml.to_s)
-      if content['company_info'].present?
+      if content&.dig('company_info')&.present?
         content = content['company_info']
         content['name'] = content.delete('conformed_name')
         if content['formerly_names'].present?

--- a/spec/sec_query/entity_spec.rb
+++ b/spec/sec_query/entity_spec.rb
@@ -37,7 +37,13 @@ describe SecQuery::Entity do
       end
     end
   end
-  
+
+  describe "Entity cannot be found", vcr: { cassette_name: "BHGE"} do
+    it 'returns nil' do
+      expect(SecQuery::Entity.find('BHGE')).to be_nil
+    end
+  end
+
   describe "People Queries", vcr: { cassette_name: "Steve Jobs"} do
   
     let(:query){ { name: "JOBS STEVEN P", :cik => "0001007844" } }


### PR DESCRIPTION
This search:
https://www.sec.gov/cgi-bin/browse-edgar?CIK=BHGE&owner=exclude&action=getcompany&Find=Search
Shows:
`No matching Ticker Symbol.`

For now, this will at least fail gracefully when this happens. 
FWIW - Another thought I have is to make this lib more ORM-like. For instance - return an empty entity with `.success?` , `.errors`, etc.